### PR TITLE
Adding initiator and request time to booking (#267)

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -35,6 +35,8 @@
 #include <rmf_task_sequence/Phase.hpp>
 #include <rmf_task_sequence/Event.hpp>
 
+#include <rclcpp/node.hpp>
+
 namespace rmf_fleet_adapter {
 namespace agv {
 
@@ -366,6 +368,13 @@ public:
   /// before the listener was set.
   FleetUpdateHandle& set_update_listener(
     std::function<void(const nlohmann::json&)> listener);
+
+  /// Get the rclcpp::Node that this fleet update handle will be using for
+  /// communication.
+  std::shared_ptr<rclcpp::Node> node();
+
+  /// const-qualified node()
+  std::shared_ptr<const rclcpp::Node> node() const;
 
   // Do not allow moving
   FleetUpdateHandle(FleetUpdateHandle&&) = delete;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -421,6 +421,17 @@ void copy_booking_data(
   booking_json["id"] = booking.id();
   booking_json["unix_millis_earliest_start_time"] =
     to_millis(booking.earliest_start_time().time_since_epoch()).count();
+  const auto requester = booking.requester();
+  if (requester.has_value())
+  {
+    booking_json["requester"] = requester.value();
+  }
+  const auto request_time = booking.request_time();
+  if (request_time.has_value())
+  {
+    booking_json["unix_millis_request_time"] =
+      to_millis(request_time.value().time_since_epoch()).count();
+  }
   // TODO(MXG): Add priority and labels
 }
 
@@ -1576,7 +1587,11 @@ void TaskManager::retreat_to_charger()
   {
     // Add a new charging task to the task queue
     const auto charging_request = rmf_task::requests::ChargeBattery::make(
-      current_state.time().value());
+      current_state.time().value(),
+      _context->requester_id(),
+      rmf_traffic_ros2::convert(_context->node()->now()),
+      nullptr,
+      true);
     const auto model = charging_request->description()->make_model(
       current_state.time().value(),
       parameters);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
@@ -53,7 +53,17 @@ rmf_task::Task::ActivePtr EmergencyPullover::start(
       std::make_shared<EmergencyPulloverDescription>()), {});
 
   const auto desc = builder.build("Emergency Pullover", "");
-  const rmf_task::Request request(task_id, context->now(), nullptr, desc, true);
+
+  const auto time_now = context->now();
+  rmf_task::Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    task_id,
+    time_now,
+    nullptr,
+    context->requester_id(),
+    time_now,
+    true);
+  const rmf_task::Request request(std::move(booking), desc);
 
   return activator.activate(
     context->make_get_state(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
@@ -70,7 +70,17 @@ rmf_task::Task::ActivePtr ResponsiveWait::start(
       ResponsiveWait::Description::make_indefinite(waiting_point)), {});
 
   const auto desc = builder.build("Responsive Wait", "");
-  const rmf_task::Request request(task_id, context->now(), nullptr, desc, true);
+
+  const auto time_now = context->now();
+  rmf_task::Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    task_id,
+    time_now,
+    nullptr,
+    context->requester_id(),
+    time_now,
+    true);
+  const rmf_task::Request request(std::move(booking), desc);
 
   return context->task_activator()->activate(
     context->make_get_state(),

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -800,8 +800,10 @@ public:
 
     static const std::vector<std::string> copy_fields = {
       "unix_millis_earliest_start_time",
+      "unix_millis_request_time",
       "priority",
-      "labels"
+      "labels",
+      "requester",
     };
 
     for (const auto& field : copy_fields)


### PR DESCRIPTION
* Adding initiator and request time to booking



* Use new booking and request API for EmergencyPullover and ResponsiveWait



* Using new booking and request API for FleetUpdateHandle



* Use requester instead of initiator, use new API



* requester name for finishing task factories



* Using reverted constructors with nullopt default parameters



* Fix build failures on build farm (#274)

* Fix style for rmf_fleet_adapter



* Make colcon test pass for rmf_traffic_ros2



* Add rmf_fleet_adapter_python to build ci



---------



* Update changelogs and bump patch (#275)



* Switch to rst changelogs (#276)



* Put the action finished callback in a schedule instead of triggering immediately (#273)

* Put the action finished callback in a schedule instead of triggering immediately



* Style



* Update CHANGELOG



* Move changelog entry into forthcoming



---------





* Revert changes to constructing finish request factories



* Using overloaded TaskPlanner constructor to pass in name of fleet update handle



* Using overloaded rmf_task make functions



* Update changelogs



* 2.2.0

* Bump 2.3.0 (#282)



* Use new booking and request API, updated legacy FullControl fleet adapter



* Added node as parameter to pybinded set_task_planner_params, to pass planner_id and time functor to finishing task factory



* Using system_clock instead of steady_clock



* Remove the need to pass a node into the set_task_planner_params python binding



---------